### PR TITLE
add rate limit for api calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.21.0",
+        "express-rate-limit": "^7.5.0",
         "morgan": "^1.10.0",
         "multer": "^1.4.5-lts.1",
         "node-appwrite": "^14.1.0"
@@ -461,6 +462,21 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/fill-range": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.21.0",
+    "express-rate-limit": "^7.5.0",
     "morgan": "^1.10.0",
     "multer": "^1.4.5-lts.1",
     "node-appwrite": "^14.1.0"

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ import uploadRoutes from './routes/uploadRoutes.js';
 import deleteRoutes from './routes/deleteRoutes.js';
 import cors from 'cors';
 import morgan from 'morgan';
+import rateLimit from 'express-rate-limit';
 
 dotenv.config(); // Load environment variables
 
@@ -17,6 +18,15 @@ app.use(morgan('dev'));
 app.use(express.json());
 
 const PORT = process.env.PORT || 3000;
+
+// Rate limiting middleware
+const globalLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+  message: 'Too many requests, please try again later.',
+});
+
+app.use("/api", globalLimiter);
 
 // Routes
 app.use('/api', uploadRoutes);


### PR DESCRIPTION
- add Dependencies (pakage.json)
`"express-rate-limit": "^7.5.0"`

- server.js
`
// Rate limiting middleware
const globalLimiter = rateLimit({
  windowMs: 15 * 60 * 1000, // 15 minutes
  max: 100, // Limit each IP to 100 requests per windowMs
  message: 'Too many requests, please try again later.',
});
app.use("/api", globalLimiter);
`